### PR TITLE
[Java] Explore maven publishing, sonatype and alternatives

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,11 +29,3 @@ POM_LICENCE_URL=http://www.opensource.org/licenses/mit-license.php
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_NAME=Countly
-
-#SIGNING SECTION
-signing.keyId=xx
-signing.password=xx
-signing.secretKeyRingFile=xx
-
-mavenCentralUsername=xx
-mavenCentralPassword=xx


### PR DESCRIPTION
For the deployment via Github Actions Following secrets need to set for this repository

MAVEN_USERNAME
MAVEN_PASSWORD
GPG_KEY // private key
GPG_KEY_ID
GPG_KEY_PASSWORD

To export GPG key run the following
`gpg2 --export-secret-keys --armor <key id> <path to secring.gpg> | grep -v '\-\-' | grep -v '^=.' | tr -d '\n'`

