### PR TITLE
Update dated-out authType check for SSLSecurity

### DIFF
--- a/sdk-java/src/main/java/ly/count/sdk/java/internal/Transport.java
+++ b/sdk-java/src/main/java/ly/count/sdk/java/internal/Transport.java
@@ -465,8 +465,12 @@ public class Transport implements X509TrustManager {
             throw new IllegalArgumentException("PublicKeyManager: X509Certificate is empty");
         }
 
-        if (!(null != authType && authType.contains("RSA"))) {
-            throw new CertificateException("PublicKeyManager: AuthType is not RSA");
+        if (authType == null) {
+            throw new CertificateException("PublicKeyManager: AuthType is null");
+        }
+
+        if (authType.isEmpty()) {
+            throw new CertificateException("PublicKeyManager: AuthType is empty");
         }
 
         // Perform standard SSL/TLS checks


### PR DESCRIPTION
As opposed here https://stackoverflow.com/a/72284709
AuthType is always "UNKNOWN" for SSLSecurity class. Thus this check always fails